### PR TITLE
Ignore temporary test files in tsconfig

### DIFF
--- a/app/templates/tsconfig.json
+++ b/app/templates/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "@baltpeter/tsconfig",
-    "include": ["src/**/*"]<% if (useTypeDoc) { %>,
+    "include": ["src/**/*"],
+    "exclude": ["**/*.tmp.ts"]<% if (useTypeDoc) { %>,
     "typedocOptions": {
         "plugin": ["typedoc-plugin-markdown"],
         "entryPoints": ["src/index.ts"],


### PR DESCRIPTION
Otherwise, `tsc` will complain every time you switch branches and use unimplemented interfaces in the test files, even though they will never be comitted.